### PR TITLE
Improve template for creating an empty repository

### DIFF
--- a/scaffolder-templates/create-empty-project/skeleton/README.md
+++ b/scaffolder-templates/create-empty-project/skeleton/README.md
@@ -1,3 +1,14 @@
-# ${{values.component_id | dump}}
+# ${{values.component_id}}
 
-${{values.description | dump}}
+${{values.description}}
+
+## Local Development
+
+### Building
+
+### Running
+
+### Testing
+
+## Deployment
+

--- a/scaffolder-templates/create-empty-project/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/create-empty-project/skeleton/catalog-info.yaml
@@ -7,6 +7,6 @@ metadata:
     github.com/project-slug: ${{values.destination.owner + "/" + values.destination.repo}}
     backstage.io/techdocs-ref: dir:.
 spec:
-  type: other
+  type: ${{values.type}}
   lifecycle: experimental
   owner: ${{values.owner | dump}}

--- a/scaffolder-templates/create-empty-project/template.yaml
+++ b/scaffolder-templates/create-empty-project/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: backstage.io/v1beta2
+apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: create-empty-project
@@ -22,6 +22,11 @@ spec:
           title: Description
           type: string
           description: Help others understand what this project is for.
+        type:
+          title: Type of Component
+          type: string
+          description: service, library, etc.
+          enum: ["service", "library", "website", "other"]
         owner:
           title: Owner
           type: string
@@ -41,6 +46,8 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
+#            allowedOwners:
+#              - RoadieHQ
   steps:
     - id: template
       name: Fetch Skeleton + Template
@@ -50,19 +57,28 @@ spec:
         copyWithoutRender:
           - .github/workflows/*
         values:
-          component_id: '{{ parameters.component_id }}'
-          description: '{{ parameters.description }}'
-          destination: '{{ parseRepoUrl parameters.repoUrl }}'
-          owner: '{{ parameters.owner }}'
+          component_id: ${{ parameters.component_id }}
+          description: ${{ parameters.description }}
+          destination: ${{ parameters.repoUrl | parseRepoUrl }}
+          owner: ${{ parameters.owner }}
+          type: ${{ parameters.type }}
 
     - id: publish
       name: Publish
       action: publish:github
       input:
         allowedHosts: ['github.com']
-        description: 'This is {{ parameters.component_id }}'
-        repoUrl: '{{ parameters.repoUrl }}'
+        description: 'This is ${{ parameters.component_id }}'
+        repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: main
+        requireCodeOwnerReviews: true
+        deleteBranchOnMerge: true
+
 
   output:
     remoteUrl: '{{ steps.publish.output.remoteUrl }}'
+    links:
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+
+


### PR DESCRIPTION
- Adds a template for the REAME with guidelines of what it should contain
- Adds an option to select the type of component
- Migrates the template to v1beta3
- Adds more settings to the github repo like enabling `requireCodeOwnerReviews`and `DeleteBranchOnMerge`