### PR TITLE
Add validation to input fields

### DIFF
--- a/scaffolder-templates/create-tenant/template.yaml
+++ b/scaffolder-templates/create-tenant/template.yaml
@@ -22,7 +22,7 @@ spec:
           description: The name of the tenant, used for the tenant slug.
           ui:autofocus: true
           maxLength: 30
-          pattern: '^([a-z][a-z-_]*)([a-z]+)$'
+          pattern: '^[a-z][a-z1-9-]*[a-z1-9]+$'
           ui:help: Lowercase characters, dash (-), and underscore (_) only.
         tenant_email_domain:
           title: Email domain
@@ -39,6 +39,16 @@ spec:
           type: string
           default: dev
           enum: ['dev', 'prod']
+        createSlack:
+          title: Create Slack Channel?
+          type: boolean
+          default: false
+          ui:widget: radio
+        pov:
+          title: PoV Tenant?
+          type: boolean
+          default: true
+          ui:widget: radio
             
   steps:
     - id: createDevTenant
@@ -71,6 +81,27 @@ spec:
                 "adminEmail": "${{ parameters.admin_email }}",
                 "tenantEnvironment": "prod",
                 "skipFailures": false
+              }
+
+    - id: addPovTag
+      name: Is it a PoV Tenant?
+      if: ${{parameters.pov === true}}
+      action: http:backstage:request
+      input:
+        method: 'POST'
+        path: proxy/fragments
+        body: |
+              {
+                "decorator": {
+                  "entityRef": "resource:default/${{ parameters.tenant_name }}",
+                  "fragment": {
+                    "metadata": {
+                      "tags": [
+                        "pov"
+                      ]
+                    }
+                  }
+                }
               }
 
   output:

--- a/scaffolder-templates/create-tenant/template.yaml
+++ b/scaffolder-templates/create-tenant/template.yaml
@@ -6,8 +6,8 @@ metadata:
   description: Send an API call to the tenant manager to create a tenant.
 
 spec:
-  owner: user:ianlink
-  type: none
+  owner: group:roadiehq/solutions
+  type: service
   parameters:
     - title: Provide some simple information
       required:
@@ -19,16 +19,21 @@ spec:
         tenant_name:
           title: Name
           type: string
-          description: No special chars, numbers as the first char, or dashes as the first or last char. 
+          description: The name of the tenant, used for the tenant slug.
           ui:autofocus: true
+          maxLength: 30
+          pattern: '^([a-z][a-z-_]*)([a-z]+)$'
+          ui:help: Lowercase characters, dash (-), and underscore (_) only.
         tenant_email_domain:
           title: Email domain
           type: string
           description: The email domain of users who will be allowed to access the tenant.
+          pattern: '^[a-zA-Z0-9-]+.[a-zA-Z0-9-]+'
         admin_email:
           title: Admin email
           type: string
           description: The email of the person who will drive the evaluation.
+          pattern: '^[a-zA-Z0-9-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-]+$'
         tenant_environment:
           title: Environment
           type: string


### PR DESCRIPTION
The following restrictions were placed on the fields:

name:
- lowercase only
- no numbers
- no special characters leading or trailing
- only `-` and `_` allowed between letters
- max length of 30

email domain:
- letters, numbers, `-`, `_`, and `.` allowed only
- no leading `@`

email:
- standard email address format