### PR TITLE
Remove unexpected property from github:publish

### DIFF
--- a/scaffolder-templates/roadie-plugin/template.yaml
+++ b/scaffolder-templates/roadie-plugin/template.yaml
@@ -54,7 +54,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: 'This is ${{ parameters.plugin_name }}'
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: main


### PR DESCRIPTION
As far as I can see github:publish never supported the "allowedHosts" property. The template now fails as the property isn't in the action input schema. In previous versions of backstage it would have been ignored.